### PR TITLE
ModalActionSheet to be displayed anywhere in component tree

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ var {
 
 var Button = require('./button.js');
 var Overlay = require('./overlay.js');
+var ModalActionSheet = require('./modal.js');
 var Sheet = require('./sheet.js');
 
 module.exports =  React.createClass({
@@ -46,6 +47,7 @@ module.exports =  React.createClass({
     },
 });
 module.exports.Button = Button;
+module.exports.ModalActionSheet = ModalActionSheet;
 
 var styles = StyleSheet.create({
     actionSheetContainer: {

--- a/modal.js
+++ b/modal.js
@@ -20,6 +20,7 @@ export default class ModalActionSheet extends React.Component {
   }
 
   show() {
+    console.log('SHOW')
     this.setState({modalVisible: true});
   }
   hide() {
@@ -27,15 +28,7 @@ export default class ModalActionSheet extends React.Component {
     //allow ActionSheet to slide down animation to be seen before hiding modal
 
     setTimeout(() => {
-      this.setState({modalVisible: false}, () => {
-        //If props.onCancel sets this.props.visible === false, this.hide() will be called 2x, but it doesn't really matter, since the sheet is already hidden.
-        //I was tempted to set the onCancel prop of <ActionSheet /> to: onCancel={this.props.onCancel || this.hide.bind(this)}
-        //but I rather just provide stable somewhat imperative behavior where it always closes when you press the Cancel button, whether you provide
-        //onCancel as a prop or not, as it's unknown whether the user will use onCancel to actually toggle the ActionSheet's visibilty or perhaps
-        //only for other application-specific purposes. So this.hide() potentially being called twice is the tradeoff for guaranteeing it closes as user's
-        //still coming from the imperative style will often expect.
-        this.props.onCancel && this.props.onCancel();
-      });
+      this.setState({modalVisible: false});
     }, 300);
   }
 
@@ -50,7 +43,7 @@ export default class ModalActionSheet extends React.Component {
       >
           <ActionSheet
             visible={this.state.sheetVisible}
-            onCancel={this.hide.bind(this)}
+            onCancel={this.props.onCancel}
             cancelText={this.props.cancelText}
           >
             {this.props.children}

--- a/modal.js
+++ b/modal.js
@@ -1,0 +1,53 @@
+import React, {Modal}  from 'react-native';
+import ActionSheet from './sheet.js';
+
+
+/**
+The idea behind this thin wrapper is that it allows you to put action sheet's anywhere in your component tree,
+not just in a component that consumes the entire screen. It's supposed to be a drop-in replacement for plain
+ActionSheet. 
+**/
+
+export default class ModalActionSheet extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+    this.state = {
+      modalVisible: this.props.visible || false,
+      sheetVisible: false,
+    }
+  }
+
+  show() {
+    this.setState({modalVisible: true});
+  }
+  hide() {
+    this.setState({modalVisible: false});
+  }
+
+  componentWillReceiveProps(nextProps) {
+    if(nextProps.visible && !this.props.visible) this.show();
+    else if(!nextProps.visible && this.props.visible) this.hide();
+  }
+
+  render() {
+    return (
+      <Modal
+        animated={false}
+        transparent={true}
+        visible={this.state.modalVisible}
+        onShow={() => this.setState({sheetVisible: true})}
+        onDismiss={() => this.setState({sheetVisible: false})}
+      >
+          <ActionSheet
+            visible={this.state.sheetVisible}
+            onCancel={this.props.onCancel}
+            cancelText={this.props.cancelText}
+          >
+            {this.props.children}
+          </ActionSheet>
+      </Modal>
+    );
+  }
+}
+
+ModalActionSheet.Button = ActionSheet.Button;

--- a/modal.js
+++ b/modal.js
@@ -1,12 +1,9 @@
 import React, {Modal}  from 'react-native';
-import ActionSheet from './sheet.js';
 
+import ActionSheet from '@remobile/react-native-action-sheet';
 
-/**
-The idea behind this thin wrapper is that it allows you to put action sheet's anywhere in your component tree,
-not just in a component that consumes the entire screen. It's supposed to be a drop-in replacement for plain
-ActionSheet. 
-**/
+//The idea behind this thin wrapper is that it allows you to put action sheet's anywhere in your component tree,
+//not just in a component that consumes the entire screen.
 
 export default class ModalActionSheet extends React.Component {
   constructor(props, context) {
@@ -17,16 +14,29 @@ export default class ModalActionSheet extends React.Component {
     }
   }
 
+  componentWillReceiveProps(nextProps) {
+    if(nextProps.visible && !this.props.visible) this.show();
+    else if(!nextProps.visible && this.props.visible) this.hide();
+  }
+
   show() {
     this.setState({modalVisible: true});
   }
   hide() {
-    this.setState({modalVisible: false});
-  }
+    this.setState({sheetVisible: false});
+    //allow ActionSheet to slide down animation to be seen before hiding modal
 
-  componentWillReceiveProps(nextProps) {
-    if(nextProps.visible && !this.props.visible) this.show();
-    else if(!nextProps.visible && this.props.visible) this.hide();
+    setTimeout(() => {
+      this.setState({modalVisible: false}, () => {
+        //If props.onCancel sets this.props.visible === false, this.hide() will be called 2x, but it doesn't really matter, since the sheet is already hidden.
+        //I was tempted to set the onCancel prop of <ActionSheet /> to: onCancel={this.props.onCancel || this.hide.bind(this)}
+        //but I rather just provide stable somewhat imperative behavior where it always closes when you press the Cancel button, whether you provide
+        //onCancel as a prop or not, as it's unknown whether the user will use onCancel to actually toggle the ActionSheet's visibilty or perhaps
+        //only for other application-specific purposes. So this.hide() potentially being called twice is the tradeoff for guaranteeing it closes as user's
+        //still coming from the imperative style will often expect.
+        this.props.onCancel && this.props.onCancel();
+      });
+    }, 300);
   }
 
   render() {
@@ -36,11 +46,11 @@ export default class ModalActionSheet extends React.Component {
         transparent={true}
         visible={this.state.modalVisible}
         onShow={() => this.setState({sheetVisible: true})}
-        onDismiss={() => this.setState({sheetVisible: false})}
+        //onDismiss={this.onDismiss} //not working in RN 22, so timers used instead; ideally onDismiss and onCancel are used in combination similar to onShow/show; perhaps in RN 23+ when onRequestClose works
       >
           <ActionSheet
             visible={this.state.sheetVisible}
-            onCancel={this.props.onCancel}
+            onCancel={this.hide.bind(this)}
             cancelText={this.props.cancelText}
           >
             {this.props.children}


### PR DESCRIPTION
The idea behind this thin wrapper is that it allows you to put action sheet's anywhere in your component tree, not just in a component that consumes the entire screen. It's supposed to be a drop-in replacement for plain ActionSheet. I think this is the way most people expect to use the action sheet by the way--i.e. as a modal. 
